### PR TITLE
Cambios en el README.es.md en alcance; {} por sangría

### DIFF
--- a/bc.json
+++ b/bc.json
@@ -1,5 +1,28 @@
 {
+    "port": 3000,
+    "address": "https://e7b8b802-2887-4ca3-96ae-81a2b89e5c9d.ws-us03.gitpod.io",
+    "editor": "gitpod",
+    "configPath": {
+        "config": "bc.json",
+        "base": ".learn",
+        "exercises": "./exercises",
+        "output": ".learn/dist"
+    },
+    "outputPath": "./.learn/dist",
+    "publicPath": "/preview",
+    "grading": "isolated",
+    "ignoreRegex": null,
+    "webpack_template": null,
+    "disable_grading": false,
+    "onCompilerSuccess": null,
     "language": "python3",
+    "compiler": "python3",
+    "tester": "pytest",
+    "actions": [
+        "run",
+        "test",
+        "reset"
+    ],
     "title": "Learn Python Functions Interactively",
     "repository": "https://github.com/4GeeksAcademy/python-functions-programming-exercises",
     "preview": "https://github.com/4GeeksAcademy/python-functions-programming-exercises/blob/master/preview.gif?raw=true",
@@ -7,5 +30,118 @@
     "duration": 10,
     "difficulty": "easy",
     "video-solutions": false,
-    "graded": true
+    "graded": true,
+    "session": 7061439075361449000,
+    "exercises": [
+        {
+            "slug": "01-hello-world",
+            "title": "01-hello-world",
+            "done": false,
+            "path": "exercises/01-hello-world",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": false
+        },
+        {
+            "slug": "02-Hello-World",
+            "title": "02-Hello-World",
+            "done": false,
+            "path": "exercises/02-Hello-World",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        },
+        {
+            "slug": "03-What-is-a-function",
+            "title": "03-What-is-a-function",
+            "done": false,
+            "path": "exercises/03-What-is-a-function",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        },
+        {
+            "slug": "04-Call-a-function",
+            "title": "04-Call-a-function",
+            "done": false,
+            "path": "exercises/04-Call-a-function",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        },
+        {
+            "slug": "05-Defining-vs-Calling-a-function",
+            "title": "05-Defining-vs-Calling-a-function",
+            "done": false,
+            "path": "exercises/05-Defining-vs-Calling-a-function",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        },
+        {
+            "slug": "06-lambda-functions",
+            "title": "06-lambda-functions",
+            "done": false,
+            "path": "exercises/06-lambda-functions",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        },
+        {
+            "slug": "07-lambda-function-two",
+            "title": "07-lambda-function-two",
+            "done": false,
+            "path": "exercises/07-lambda-function-two",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        },
+        {
+            "slug": "08-Function-that-returns",
+            "title": "08-Function-that-returns",
+            "done": false,
+            "path": "exercises/08-Function-that-returns",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        },
+        {
+            "slug": "09-Function-parameters",
+            "title": "09-Function-parameters",
+            "done": false,
+            "path": "exercises/09-Function-parameters",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        },
+        {
+            "slug": "10-Array-Methods",
+            "title": "10-Array-Methods",
+            "done": false,
+            "path": "exercises/10-Array-Methods",
+            "translations": [
+                "es",
+                "us"
+            ],
+            "graded": true
+        }
+    ]
 }

--- a/exercises/05-Defining-vs-Calling-a-function/README.es.md
+++ b/exercises/05-Defining-vs-Calling-a-function/README.es.md
@@ -17,7 +17,7 @@ Nombres de ejemplo: add_two_integers , calculate_taxes , get_random_number, etc.
 
 **Parámetros:** puedes definir tantos parámetros como desees, más aún, si los necesitas. La cantidad de parámetros dependerá de las operaciones realizadas dentro de la función. Ejemplo: si la función está agregando dos enteros (3 + 4), esto significa que la función necesitará dos parámetros (uno para cada entero).
 
-**Alcance:** Todas las operaciones que realizará la función deben estar dentro de `{` `}` (llaves). Cualquier cosa por fuera, no se considerará como parte de la función. Esto se llama **el alcance** (scope), y podría ser local (dentro de la función) y global (fuera de la función).
+**Ámbito:** Todo el código que contenga la función debe tener una sangría a la derecha, todo lo que esté en una sangría diferente no será considerado como parte de la función, esto se llama **ámbito**, y puede ser local (dentro de la función) y global (fuera de la función).
 
 **El retorno**: no todas las funciones necesitan devolver algo, pero se recomienda que lo haga.
 Consejo: devolviendo `None` es un buen valor por defecto para cuando, aún, no sabes si se necesita devolver algo.


### PR DESCRIPTION
Buenas tardes,
en las instrucciones del ejercicio 5 en español cuando describen las partes de una función, usa { } para encerrarla, pero eso es para Java Script. Lo cambié por sangría, como aparece en las instrucciones en inglés.