### PR TITLE
Error en el código de ejemplo

### DIFF
--- a/exercises/06-lambda-functions/README.es.md
+++ b/exercises/06-lambda-functions/README.es.md
@@ -29,5 +29,5 @@ Así es como declararías una función normal
 ```python
 # this function return True if a number is odd.
 def is_odd(num):
-    return (num % 2)! == 0:
+    return (num % 2) != 0
 ```


### PR DESCRIPTION
En la linea 32 dice:
return (num % 2)! == 0: En python esta sintaxis es incorrecta.
Lo correcto es:
return (num % 2) != 0