### PR TITLE
fix: update Python devcontainer image to resolve Node 16

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.10-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			"nodeGypDependencies": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.10-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/python:3.10-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			"nodeGypDependencies": true,


### PR DESCRIPTION
## Problem

When opening a new Codespace, `learnpack start` failed immediately with:

`[ERR_REQUIRE_ESM]: require() of ES Module (...) not supported Error: command start not found`


LearnPack 5.x depends on packages (e.g. `syllable`) that are ESM-only and
incompatible with Node 16.

## Root cause

The base image `mcr.microsoft.com/devcontainers/python:0-3.10` ships with
nvm and **Node 16.20.2 pre-installed**. When the `node:1` dev container
feature runs and finds nvm already present, it attempts to install Node 22
on top of it, but the installation silently fails or does not update the
default alias. As a result, `onCreateCommand` runs `npm install -g` against
the only available Node version — 16 — and LearnPack 5.x ends up installed
in an incompatible runtime.

## Fix

Replace the legacy base image with the current official variant:

```diff
- "image": "mcr.microsoft.com/devcontainers/python:0-3.10"
+ "image": "mcr.microsoft.com/devcontainers/python:3.10-bookworm"